### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/utils/print.ts
+++ b/frontend/src/utils/print.ts
@@ -89,7 +89,7 @@ Print.prototype = {
 
     for (let k2 = 0; k2 < textareas.length; k2++) {
       if (textareas[k2].type == "textarea") {
-        textareas[k2].innerHTML = textareas[k2].value;
+        textareas[k2].textContent = textareas[k2].value;
       }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/pylover7/MaterialManager/security/code-scanning/1](https://github.com/pylover7/MaterialManager/security/code-scanning/1)

To fix the issue, we need to ensure that the `value` of the `<textarea>` is properly escaped before assigning it to `innerHTML`. Escaping ensures that any HTML meta-characters in the `value` are treated as plain text rather than HTML. A utility function like `textContent` or a dedicated escaping function can be used for this purpose.

The best approach is to replace the direct assignment of `textareas[k2].value` to `textareas[k2].innerHTML` with an assignment to `textContent`. This ensures that the `value` is treated as plain text, preventing any potential XSS vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
